### PR TITLE
Fix newline handling on Windows

### DIFF
--- a/Linguini.Syntax/Ast/Pattern.cs
+++ b/Linguini.Syntax/Ast/Pattern.cs
@@ -34,17 +34,37 @@ namespace Linguini.Syntax.Ast
 
     public class TextElementPlaceholder : IPatternElementPlaceholder
     {
+        /// <summary>
+        /// Start of text slice
+        /// </summary>
         public int Start { get; }
-        public int End { get; }
-        public int Indent { get; }
-        public TextElementPosition Role { get; }
 
-        public TextElementPlaceholder(int start, int end, int indent, TextElementPosition role)
+        /// <summary>
+        /// End of text slice
+        /// </summary>
+        public int End { get; }
+        /// <summary>
+        /// Indent of Text element
+        /// </summary>
+        public int Indent { get; }
+        
+        /// <summary>
+        /// Text element position used in pattern processing
+        /// </summary>
+        public TextElementPosition Role { get; }
+        
+        /// <summary>
+        /// Boolean flag to add an EOL to text slice. It's used on Windows to make sure newlines are processed correctly
+        /// </summary>
+        public bool MissingEol { get; } 
+
+        public TextElementPlaceholder(int start, int end, int indent, TextElementPosition role, bool missingEol)
         {
             Start = start;
             End = end;
             Indent = indent;
             Role = role;
+            MissingEol = missingEol;
         }
     }
 }

--- a/Linguini.Syntax/Parser/LinguiniParser.cs
+++ b/Linguini.Syntax/Parser/LinguiniParser.cs
@@ -525,7 +525,8 @@ namespace Linguini.Syntax.Parser
                                 sliceStart,
                                 text.End,
                                 indent,
-                                textElementRole
+                                textElementRole,
+                                text.TerminationReason == TextElementTermination.CRLF
                             ));
                         }
                     }
@@ -571,7 +572,18 @@ namespace Linguini.Syntax.Parser
                                 }
                             }
 
-                            var value = _reader.ReadSlice(start, end);
+                            ReadOnlyMemory<char> value;
+                            if (textLiteral.MissingEol)
+                            {
+                                var str = _reader.ReadSlice(start, end) + "\n";
+                                value = str.AsMemory();
+                            }
+                            else
+                            {
+                                value = _reader.ReadSlice(start, end);
+                            }
+                            // var value = _reader.ReadSlice(start, end);
+
                             if (lastNonBlank == i)
                             {
 #if NET5_0_OR_GREATER 
@@ -625,17 +637,18 @@ namespace Linguini.Syntax.Parser
                 else if ('\r'.EqualsSpans(span)
                          && '\n'.EqualsSpans(_reader.PeekCharSpan(1)))
                 {
-                    _reader.Position += 2;
-                    _reader.Row += 1;
-
-                    // This takes one less element because it converts CRLF endings
-                    // to LF endings
+                    // If this is one `/r/n` (CRLF) line ending we take position before CRLF
+                    // and set flag in TextElementPlaceholder that value is missing a EOL mark (which is LF)
                     textElement = new TextSlice(
                         startPos,
-                        _reader.Position - 1,
+                        _reader.Position,
                         textElementType,
                         TextElementTermination.CRLF
                     );
+                    
+                    _reader.Position += 2;
+                    _reader.Row += 1;
+                    
                     error = null;
                     return true;
                 }


### PR DESCRIPTION
Tests for Windows are failing to convert CRLF to LF.

These changes should fix test failures.